### PR TITLE
Push a new ci job to the default branch

### DIFF
--- a/.github/workflows/tests_trigger.yml
+++ b/.github/workflows/tests_trigger.yml
@@ -1,0 +1,67 @@
+name: Tests
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/test-results') }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: refs/pull/${{ github.event.issue.number }}/merge
+
+      - uses: actions/setup-node@v4
+        name: Install Node.js
+        with:
+          node-version: 21
+
+      - name: Install test dependencies
+        run: npm ci
+        working-directory: tests
+
+      - name: Run tests and generate report
+        id: tests
+        run: npm run test:report
+        working-directory: tests
+        continue-on-error: true
+
+      - name: Comment PR with test results
+        uses: actions/github-script@v7
+        if: always() && (github.event_name == 'pull_request' || github.event.inputs.pr_number)
+        with:
+          script: |
+            const { commentTestResults } = require('./.github/scripts/comment-test-results.js');
+            const prNumber = github.event.inputs?.pr_number || context.issue.number;
+            const customContext = {
+              ...context,
+              issue: { number: prNumber }
+            };
+            await commentTestResults({ github, context: customContext });
+
+      - name: Check test results and fail if needed
+        if: always()
+        run: |
+          if [ -f tests/.test-reports/merged-report.json ]; then
+            failures=$(node -e "
+              const fs = require('fs');
+              const report = JSON.parse(fs.readFileSync('tests/.test-reports/merged-report.json', 'utf8'));
+              console.log(report.stats.failures || 0);
+            ")
+            if [ "$failures" -gt "0" ]; then
+              echo "Tests failed: $failures failure(s) found"
+              exit 1
+            else
+              echo "All tests passed"
+            fi
+          else
+            echo "Test report not found, assuming failure"
+            exit 1
+          fi


### PR DESCRIPTION
Following the docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment
>  This event will only trigger a workflow run **if the workflow file exists on the default branch**.

If this does not work, I will remove it in #27 