### PR TITLE
Dynamic chains

### DIFF
--- a/backend/wavs-home/wavs.toml
+++ b/backend/wavs-home/wavs.toml
@@ -12,32 +12,6 @@ prometheus = "http://localhost:9090"
 
 # == Ethereum chains ==
 
-# Local
-[default.chains.evm.31337]
-ws_endpoint = "ws://localhost:8548"
-http_endpoint = "http://localhost:8548"
-poll_interval_ms = 7000
-
-[default.chains.evm.31338]
-ws_endpoint = "ws://localhost:8549"
-http_endpoint = "http://localhost:8549"
-poll_interval_ms = 7000
-
-[default.chains.evm.31339]
-ws_endpoint = "ws://localhost:8550"
-http_endpoint = "http://localhost:8550"
-poll_interval_ms = 7000
-
-[default.chains.evm.31340]
-ws_endpoint = "ws://localhost:8551"
-http_endpoint = "http://localhost:8551"
-poll_interval_ms = 7000
-
-[default.chains.evm.31341]
-ws_endpoint = "ws://localhost:8552"
-http_endpoint = "http://localhost:8552"
-poll_interval_ms = 7000
-
 # Testnet
 
 [default.chains.evm.11155111]

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -433,18 +433,26 @@ tasks:
       - sh: "command -v curl"
         msg: "curl is required but not installed"
     cmds:
-      - |
+      - >
         curl -X POST "{{.WAVS_ENDPOINT}}/chains" \
           -H "Content-Type: application/json" \
           -d '{
             "chain": "{{.NAMESPACE}}:{{.CHAIN_ID}}",
             "config": {
               "type": "evm",
-              "chain_id": "{{.CHAIN_ID}}",
-              "ws_endpoint": {{.WS_ENDPOINT | quote}},
-              "http_endpoint": {{.HTTP_ENDPOINT | quote}},
-              "faucet_endpoint": {{.FAUCET_ENDPOINT | quote}},
-              "poll_interval_ms": {{.POLL_INTERVAL_MS | atoi | default 7000}}
+              "chain_id": "{{.CHAIN_ID}}"
+              {{- if .WS_ENDPOINT}},
+              "ws_endpoint": "{{.WS_ENDPOINT}}"
+              {{- end}}
+              {{- if .HTTP_ENDPOINT}},
+              "http_endpoint": "{{.HTTP_ENDPOINT}}"
+              {{- end}}
+              {{- if .FAUCET_ENDPOINT}},
+              "faucet_endpoint": "{{.FAUCET_ENDPOINT}}"
+              {{- end}}
+              {{- if .POLL_INTERVAL_MS}},
+              "poll_interval_ms": {{.POLL_INTERVAL_MS}}
+              {{- end}}
             }
           }'
 

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -380,6 +380,9 @@ tasks:
   ###################################################################
   ##################### CHAIN CONFIGURATION ##########################
   ###################################################################
+  # Only for local evm instances
+  # Eventually need to refactor entire codebase to allow for local <=> testnet
+  # Since everything is heavily dependent on DEPLOY_ENV atm
   configure-chains:
     status:
       - '[ "{{.DEPLOY_ENV}}" != "LOCAL" ]'
@@ -389,9 +392,9 @@ tasks:
         sh: seq 1 {{.ACTIVE_CHAIN_COUNT}}
     deps:
       - for: { var: CHAIN_RANGE }
-        task: configure-chain-{{.ITEM}}
+        task: configure-evm-chain-{{.ITEM}}
 
-  configure-chain-*:
+  configure-evm-chain-*:
     desc: "Configure a single chain across all active WAVS operators"
     vars:
       CHAIN_NUMBER: "{{index .MATCH 0}}"

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -28,6 +28,8 @@ tasks:
         vars:
           OPERATORS: "{{.OPERATORS}}"
       - task: start-telemetry
+    cmds:
+      - task: configure-chains
 
   stop:
     desc: "Stops all backend services"
@@ -374,6 +376,74 @@ tasks:
       ENV_VAR_NAME: "WAVS_SUBMISSION_MNEMONIC_{{.WAVS_INSTANCE}}"
     cmds:
       - echo "${{.ENV_VAR_NAME}}"
+
+  ###################################################################
+  ##################### CHAIN CONFIGURATION ##########################
+  ###################################################################
+  configure-chains:
+    status:
+      - '[ "{{.DEPLOY_ENV}}" != "LOCAL" ]'
+    desc: "Configure chains across all active WAVS operators"
+    vars:
+      CHAIN_RANGE:
+        sh: seq 1 {{.ACTIVE_CHAIN_COUNT}}
+    deps:
+      - for: { var: CHAIN_RANGE }
+        task: configure-chain-{{.ITEM}}
+
+  configure-chain-*:
+    desc: "Configure a single chain across all active WAVS operators"
+    vars:
+      CHAIN_NUMBER: "{{index .MATCH 0}}"
+      CHAIN_NAME:
+        sh: task backend:get-chain-name-{{.CHAIN_NUMBER}}
+      RPC_URL:
+        sh: task backend:get-evm-rpc-url-{{.CHAIN_NUMBER}}
+      WAVS_RANGE:
+        sh: seq 1 {{.ACTIVE_WAVS_COUNT}}
+      POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS | default 7000}}"
+    requires:
+      vars: [CHAIN_NUMBER]
+    deps:
+      - for: { var: WAVS_RANGE }
+        task: add-evm-chain
+        vars:
+          CHAIN_NAME: "{{.CHAIN_NAME}}"
+          OPERATOR: "{{.ITEM}}"
+          HTTP_ENDPOINT: "{{.RPC_URL}}"
+          POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
+
+  add-evm-chain:
+    desc: "Add a new EVM chain to WAVS via POST /chains endpoint"
+    requires:
+      vars: [NAMESPACE, CHAIN_NAME, OPERATOR]
+    vars:
+      HTTP_ENDPOINT: "{{.HTTP_ENDPOINT}}"
+      NAMESPACE: '{{ index (.CHAIN_NAME | splitList ":") 0 }}'
+      CHAIN_ID: '{{ index (.CHAIN_NAME | splitList ":") 1 }}'
+      WS_ENDPOINT: "{{.WS_ENDPOINT}}"
+      FAUCET_ENDPOINT: "{{.FAUCET_ENDPOINT}}"
+      POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
+      WAVS_ENDPOINT:
+        sh: task backend:get-wavs-endpoint-{{.OPERATOR}}
+    preconditions:
+      - sh: "command -v curl"
+        msg: "curl is required but not installed"
+    cmds:
+      - |
+        curl -X POST "{{.WAVS_ENDPOINT}}/chains" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "chain": "{{.NAMESPACE}}:{{.CHAIN_ID}}",
+            "config": {
+              "type": "evm",
+              "chain_id": "{{.CHAIN_ID}}",
+              "ws_endpoint": {{.WS_ENDPOINT | quote}},
+              "http_endpoint": {{.HTTP_ENDPOINT | quote}},
+              "faucet_endpoint": {{.FAUCET_ENDPOINT | quote}},
+              "poll_interval_ms": {{.POLL_INTERVAL_MS | atoi | default 7000}}
+            }
+          }'
 
   ###################################################################
   ##################### TELEMETRY ###################################

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -29,6 +29,7 @@ tasks:
           OPERATORS: "{{.OPERATORS}}"
       - task: start-telemetry
     cmds:
+      - sleep 1
       - task: configure-local-chains
 
   stop:
@@ -437,7 +438,7 @@ tasks:
           POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
 
   add-evm-chain:
-    desc: "Add a new EVM chain to WAVS via POST /chains endpoint"
+    desc: "Add a new EVM chain to WAVS via POST /dev/chains endpoint"
     requires:
       vars: [ENDPOINT, NAMESPACE, CHAIN_NAME]
     vars:
@@ -452,7 +453,7 @@ tasks:
         msg: "curl is required but not installed"
     cmds:
       - >
-        curl --fail-with-body -X POST "{{.ENDPOINT}}/chains" \
+        curl --fail-with-body -X POST "{{.ENDPOINT}}/dev/chains" \
           -H "Content-Type: application/json" \
           -d '{
             "chain": "{{.NAMESPACE}}:{{.CHAIN_ID}}",

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -29,7 +29,7 @@ tasks:
           OPERATORS: "{{.OPERATORS}}"
       - task: start-telemetry
     cmds:
-      - task: configure-chains
+      - task: configure-local-chains
 
   stop:
     desc: "Stops all backend services"
@@ -183,6 +183,15 @@ tasks:
         sh: task -s backend:get-anvil-port-{{.CHAIN_NUMBER}}
     cmds:
       - echo "http://localhost:{{.ANVIL_PORT}}"
+
+  get-local-evm-ws-url-*:
+    desc: "Get the local Anvil WebSocket URL for a chain number"
+    vars:
+      CHAIN_NUMBER: "{{index .MATCH 0}}"
+      ANVIL_PORT:
+        sh: task -s backend:get-anvil-port-{{.CHAIN_NUMBER}}
+    cmds:
+      - echo "ws://localhost:{{.ANVIL_PORT}}"
 
   get-chain-name-*:
     desc: "Get the chain name for a chain number"
@@ -383,7 +392,7 @@ tasks:
   # Only for local evm instances
   # Eventually need to refactor entire codebase to allow for local <=> testnet
   # Since everything is heavily dependent on DEPLOY_ENV atm
-  configure-chains:
+  configure-local-chains:
     status:
       - '[ "{{.DEPLOY_ENV}}" != "LOCAL" ]'
     desc: "Configure chains across all active WAVS operators"
@@ -392,16 +401,18 @@ tasks:
         sh: seq 1 {{.ACTIVE_CHAIN_COUNT}}
     deps:
       - for: { var: CHAIN_RANGE }
-        task: configure-evm-chain-{{.ITEM}}
+        task: configure-local-evm-chain-{{.ITEM}}
 
-  configure-evm-chain-*:
+  configure-local-evm-chain-*:
     desc: "Configure a single chain across all active WAVS operators"
     vars:
       CHAIN_NUMBER: "{{index .MATCH 0}}"
       CHAIN_NAME:
-        sh: task backend:get-chain-name-{{.CHAIN_NUMBER}}
+        sh: task backend:get-local-chain-name-{{.CHAIN_NUMBER}}
       RPC_URL:
-        sh: task backend:get-evm-rpc-url-{{.CHAIN_NUMBER}}
+        sh: task backend:get-local-evm-rpc-url-{{.CHAIN_NUMBER}}
+      WS_ENDPOINT:
+        sh: task backend:get-local-evm-ws-url-{{.CHAIN_NUMBER}}
       WAVS_RANGE:
         sh: seq 1 {{.ACTIVE_WAVS_COUNT}}
       POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS | default 7000}}"
@@ -411,15 +422,24 @@ tasks:
       - for: { var: WAVS_RANGE }
         task: add-evm-chain
         vars:
+          ENDPOINT:
+            sh: task backend:get-wavs-endpoint-{{.ITEM}}
           CHAIN_NAME: "{{.CHAIN_NAME}}"
-          OPERATOR: "{{.ITEM}}"
           HTTP_ENDPOINT: "{{.RPC_URL}}"
+          WS_ENDPOINT: "{{.WS_ENDPOINT}}"
+          POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
+      - task: add-evm-chain
+        vars:
+          ENDPOINT: "{{.WAVS_AGGREGATOR_ENDPOINT}}"
+          CHAIN_NAME: "{{.CHAIN_NAME}}"
+          HTTP_ENDPOINT: "{{.RPC_URL}}"
+          WS_ENDPOINT: "{{.WS_ENDPOINT}}"
           POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
 
   add-evm-chain:
     desc: "Add a new EVM chain to WAVS via POST /chains endpoint"
     requires:
-      vars: [NAMESPACE, CHAIN_NAME, OPERATOR]
+      vars: [ENDPOINT, NAMESPACE, CHAIN_NAME]
     vars:
       HTTP_ENDPOINT: "{{.HTTP_ENDPOINT}}"
       NAMESPACE: '{{ index (.CHAIN_NAME | splitList ":") 0 }}'
@@ -427,14 +447,12 @@ tasks:
       WS_ENDPOINT: "{{.WS_ENDPOINT}}"
       FAUCET_ENDPOINT: "{{.FAUCET_ENDPOINT}}"
       POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS}}"
-      WAVS_ENDPOINT:
-        sh: task backend:get-wavs-endpoint-{{.OPERATOR}}
     preconditions:
       - sh: "command -v curl"
         msg: "curl is required but not installed"
     cmds:
       - >
-        curl -X POST "{{.WAVS_ENDPOINT}}/chains" \
+        curl --fail-with-body -X POST "{{.ENDPOINT}}/chains" \
           -H "Content-Type: application/json" \
           -d '{
             "chain": "{{.NAMESPACE}}:{{.CHAIN_ID}}",

--- a/taskfile/backend.yml
+++ b/taskfile/backend.yml
@@ -29,8 +29,10 @@ tasks:
           OPERATORS: "{{.OPERATORS}}"
       - task: start-telemetry
     cmds:
-      - sleep 1
       - task: configure-local-chains
+        vars:
+          CHAINS: "{{.CHAINS}}"
+          OPERATORS: "{{.OPERATORS}}"
 
   stop:
     desc: "Stops all backend services"
@@ -397,15 +399,21 @@ tasks:
     status:
       - '[ "{{.DEPLOY_ENV}}" != "LOCAL" ]'
     desc: "Configure chains across all active WAVS operators"
+    requires:
+      vars: [CHAINS, OPERATORS]
     vars:
       CHAIN_RANGE:
-        sh: seq 1 {{.ACTIVE_CHAIN_COUNT}}
+        sh: seq 1 {{.CHAINS}}
     deps:
       - for: { var: CHAIN_RANGE }
         task: configure-local-evm-chain-{{.ITEM}}
+        vars:
+          OPERATORS: "{{.OPERATORS}}"
 
   configure-local-evm-chain-*:
     desc: "Configure a single chain across all active WAVS operators"
+    requires:
+      vars: [CHAIN_NUMBER, OPERATORS]
     vars:
       CHAIN_NUMBER: "{{index .MATCH 0}}"
       CHAIN_NAME:
@@ -415,10 +423,8 @@ tasks:
       WS_ENDPOINT:
         sh: task backend:get-local-evm-ws-url-{{.CHAIN_NUMBER}}
       WAVS_RANGE:
-        sh: seq 1 {{.ACTIVE_WAVS_COUNT}}
+        sh: seq 1 {{.OPERATORS}}
       POLL_INTERVAL_MS: "{{.POLL_INTERVAL_MS | default 7000}}"
-    requires:
-      vars: [CHAIN_NUMBER]
     deps:
       - for: { var: WAVS_RANGE }
         task: add-evm-chain

--- a/taskfile/docker.yml
+++ b/taskfile/docker.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 vars:
-  WAVS_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs:5f4d496{{if eq .ARCH "arm64"}}-arm64{{end}}'
+  WAVS_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs:a6efaaf{{if eq .ARCH "arm64"}}-arm64{{end}}'
   MIDDLEWARE_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs-middleware:89fa0dd{{if eq .ARCH "arm64"}}-arm64{{end}}'
   FOUNDRY_DOCKER_IMAGE: "ghcr.io/foundry-rs/foundry:latest"
   JAEGER_DOCKER_IMAGE: "jaegertracing/jaeger:2.5.0"

--- a/taskfile/docker.yml
+++ b/taskfile/docker.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 vars:
-  WAVS_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs:1.3.0{{if eq .ARCH "arm64"}}-arm64{{end}}'
+  WAVS_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs:5f4d496{{if eq .ARCH "arm64"}}-arm64{{end}}'
   MIDDLEWARE_DOCKER_IMAGE: 'ghcr.io/lay3rlabs/wavs-middleware:89fa0dd{{if eq .ARCH "arm64"}}-arm64{{end}}'
   FOUNDRY_DOCKER_IMAGE: "ghcr.io/foundry-rs/foundry:latest"
   JAEGER_DOCKER_IMAGE: "jaegertracing/jaeger:2.5.0"

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "test": "mkdir -p .test-reports && bun test src --reporter=junit --reporter-outfile=.test-reports/junit.xml --timeout 300000",
+        "test": "mkdir -p .test-reports && bun test src --reporter=junit --reporter-outfile=.test-reports/junit.xml --timeout 600000",
         "test:coverage": "mkdir -p .test-reports/coverage && bun test src --coverage --coverage-reporter=lcov --coverage-dir=.test-reports/coverage",
         "test:watch": "bun test src --watch",
         "test:clean": "rm -rf .test-reports coverage"

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "test": "mkdir -p .test-reports && bun test src --reporter=junit --reporter-outfile=.test-reports/junit.xml --timeout 120000",
+        "test": "mkdir -p .test-reports && bun test src --reporter=junit --reporter-outfile=.test-reports/junit.xml --timeout 300000",
         "test:coverage": "mkdir -p .test-reports/coverage && bun test src --coverage --coverage-reporter=lcov --coverage-dir=.test-reports/coverage",
         "test:watch": "bun test src --watch",
         "test:clean": "rm -rf .test-reports coverage"

--- a/tests/src/multi-chain-operator-sync.test.ts
+++ b/tests/src/multi-chain-operator-sync.test.ts
@@ -23,7 +23,7 @@ describe(PROJECT_NAME.toUpperCase(), function () {
   });
 
   describe("All tests", function () {
-    test("run-tests", async () => {
+    test(PROJECT_NAME + " run-tests", async () => {
       backendManager.assertRunning();
 
       await execAsync("task", ["run-tests"], {

--- a/tests/src/multi-chain-quorum-sync.test.ts
+++ b/tests/src/multi-chain-quorum-sync.test.ts
@@ -23,7 +23,7 @@ describe(PROJECT_NAME.toUpperCase(), function () {
   });
 
   describe("All tests", function () {
-    test("run-tests", async () => {
+    test(PROJECT_NAME + " run-tests", async () => {
       backendManager.assertRunning();
 
       await execAsync("task", ["run-tests"], {

--- a/tests/src/operator-updater.test.ts
+++ b/tests/src/operator-updater.test.ts
@@ -23,7 +23,7 @@ describe(PROJECT_NAME.toUpperCase(), function () {
   });
 
   describe("All tests", function () {
-    test("run-tests", async () => {
+    test(PROJECT_NAME + " run-tests", async () => {
       backendManager.assertRunning();
 
       await execAsync("task", ["run-tests"], {

--- a/tests/src/wavs-drand.test.ts
+++ b/tests/src/wavs-drand.test.ts
@@ -23,7 +23,7 @@ describe(PROJECT_NAME.toUpperCase(), function () {
   });
 
   describe("All tests", function () {
-    test("run-tests", async () => {
+    test(PROJECT_NAME + " run-tests", async () => {
       backendManager.assertRunning();
 
       await execAsync("task", ["run-tests"], {


### PR DESCRIPTION
closes #59 

Adds a new final step to `task backend:start` to configure chains `task backend:configure-chains`
This only runs in `DEPLOY_ENV=LOCAL` (we keep testnet configuration in wavs.toml), but this sets up the plumbing going forward.

TODO:
- [x] get tests running

I think this error is a bug on WAVS:
```
2025-09-25T18:46:03.130785Z wavs::subsystems::trigger: No chain config found for evm:31337
```